### PR TITLE
docs: add hello endpoint for hardware testing

### DIFF
--- a/docs/hello/index.html
+++ b/docs/hello/index.html
@@ -1,0 +1,1 @@
+Hello MicroCat.1


### PR DESCRIPTION
  ## Summary
  - Add `docs/hello/index.html` returning "Hello MicroCat.1"
  - Provides a lightweight alternative to https://mechatrax.com for LTE hardware testing

  ## Background
  https://mechatrax.com is too large for use as an HTTP GET target in hardware tests.
  A minimal endpoint at https://mechatrax.github.io/microcat1/hello/ reduces data usage
  and speeds up test execution on the actual device.

  ## Verification
  Confirmed via curl on GitHub Pages (tsuyoshi-okuma fork):
  $ curl https://tsuyoshi-okuma.github.io/microcat1/hello/
  Hello MicroCat.1